### PR TITLE
Add option to make `npm install` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You provide configuration properties within your workflow by using the `with` pr
 | useEslintrc | boolean | true | false | Use eslintrc? |
 | useEslintIgnore | boolean | true | false | Use eslintignore? |
 | fix | boolean | false | false | Commit fixes when possible (UNFINISHED) |
+| npmInstall | boolean | true | false | Runs `npm install` for you |
 
 > The official settings can always be seen by viewing the [`action.yml`](https://github.com/bradennapier/eslint-plus-action/blob/master/action.yml) schema for the action.
 
@@ -124,6 +125,24 @@ jobs:
         github-token: ${{secrets.GITHUB_TOKEN}}
         issueSummaryType: full
         reportIgnoredFiles: true
+```
+
+### With a manual `npm install` step
+
+```yml
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm ci
+      - name: Run a build step
+        run: npm run build
+      - uses: bradennapier/eslint-plus-action@v2
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          npmInstall: false
 ```
 
 ## More Previews

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You provide configuration properties within your workflow by using the `with` pr
 | useEslintrc | boolean | true | false | Use eslintrc? |
 | useEslintIgnore | boolean | true | false | Use eslintignore? |
 | fix | boolean | false | false | Commit fixes when possible (UNFINISHED) |
-| npmInstall | boolean | true | false | Runs `npm install` for you |
+| npmInstall | boolean | false | false | Force run npm ci (or yarn) for you. If you do not use this option, be sure to install the project dependencies before running this action.  By default it will run if a node_modules directory is not found or this is set to true |
 
 > The official settings can always be seen by viewing the [`action.yml`](https://github.com/bradennapier/eslint-plus-action/blob/master/action.yml) schema for the action.
 
@@ -125,24 +125,6 @@ jobs:
         github-token: ${{secrets.GITHUB_TOKEN}}
         issueSummaryType: full
         reportIgnoredFiles: true
-```
-
-### With a manual `npm install` step
-
-```yml
-jobs:
-  eslint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: npm ci
-      - name: Run a build step
-        run: npm run build
-      - uses: bradennapier/eslint-plus-action@v2
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          npmInstall: false
 ```
 
 ## More Previews

--- a/action.yml
+++ b/action.yml
@@ -53,8 +53,13 @@ inputs:
   fix:
     description: 'Run with --fix? Defaults to false'
     required: false
+  npmInstall:
+    description: 'Run npm install (or yarn) for you. If you do not use this option, do the npm install step yourself, before running this action. Defaults to true'
+    required: false
+    default: true
 runs:
   using: docker
   image: Dockerfile
   args:
     - "${{ inputs.github-token }}"
+    - "${{ inputs.npmInstall }}"

--- a/action.yml
+++ b/action.yml
@@ -54,9 +54,9 @@ inputs:
     description: 'Run with --fix? Defaults to false'
     required: false
   npmInstall:
-    description: 'Run npm install (or yarn) for you. If you do not use this option, do the npm install step yourself, before running this action. Defaults to true'
+    description: 'Force run npm ci (or yarn) for you. If you do not use this option, be sure to install the project dependencies before running this action.  By default it will run if a node_modules directory is not found or this is set to true'
     required: false
-    default: true
+    default: false
 runs:
   using: docker
   image: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,9 +21,11 @@ set -e
 
 echo "First Install";
 ls -alh
-echo "Install Yarn"
-[ -f yarn.lock ] && yarn install --frozen-lockfile --prefer-offline
-[ -f package-lock.json ] && npm install
+if [ "$2" = true ] ; then
+    echo "Install Yarn"
+    [ -f yarn.lock ] && yarn install --frozen-lockfile --prefer-offline
+    [ -f package-lock.json ] && npm install
+fi
 
 pushd /action
 echo "Yarn Action Install"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ set -e
 
 echo "First Install";
 ls -alh
-if [ "$2" = true ] ; then
+if [ ! -d "./node_modules" ] || [ "$2" = true ] ; then
     echo "Install Yarn"
     [ -f yarn.lock ] && yarn install --frozen-lockfile --prefer-offline
     [ -f package-lock.json ] && npm install

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ ls -alh
 if [ ! -d "./node_modules" ] || [ "$2" = true ] ; then
     echo "Install Yarn"
     [ -f yarn.lock ] && yarn install --frozen-lockfile --prefer-offline
-    [ -f package-lock.json ] && npm install
+    [ -f package-lock.json ] && npm ci
 fi
 
 pushd /action


### PR DESCRIPTION
First of all, thanks for the action. It's awesome 🙂

We had a problem using it, though. We use a lerna monorepo and the `npm install` that you do inside the docker container fails, so I've added an option to avoid running `npm install` in the container and thus allow people to run their necessary install and/or build scripts in a previous step of their workflow, like this:

```yaml
jobs:
  eslint:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout Repo
        uses: actions/checkout@v2
      - name: Install dependencies
        run: npm ci
      - name: Run a build step
        run: npm run build
      - uses: bradennapier/eslint-plus-action@v2
        with:
          github-token: ${{secrets.GITHUB_TOKEN}}
          npmInstall: false
```

https://github.com/frontity/frontity/blob/refactor-analytics-event/.github/workflows/eslint.yml

The option is called `npmInstall` and has a default of `true`.

Let me know what you think.