### PR TITLE
Provide github token secret by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,40 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-
-    # - name: Get yarn cache directory path
-    #   id: yarn-cache-dir-path
-    #   run: echo "::set-output name=dir::$(yarn cache dir)"
-
-    # - uses: actions/cache@v2
-    #   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-    #   with:
-    #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-    #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-yarn-
-
-    # - name: Cache node_modules
-    #   id: cache-node-modules
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: node_modules
-    #     key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
-
-    # - name: Install Dependencies
-    #   if: steps.yarn-cache.outputs.cache-hit != 'true' # Over here!
-    #   run: yarn install --frozen-lockfile --prefer-offline
-
-    # - name: Install Cached Dependencies
-    #   if: steps.yarn-cache.outputs.cache-hit == 'true' # Over here!
-    #   run: yarn install --frozen-lockfile --offline
-
-    # - name: Build
-    #   run: yarn build
-      
     - uses: ./
       with: 
-        github-token: ${{secrets.PR_GITHUB_TOKEN}}
         reportIgnoredFiles: true

--- a/README.md
+++ b/README.md
@@ -72,32 +72,6 @@ You provide configuration properties within your workflow by using the `with` pr
 
 > The official settings can always be seen by viewing the [`action.yml`](https://github.com/bradennapier/eslint-plus-action/blob/master/action.yml) schema for the action.
 
-## PR from Forks
-
-There are some considerations when working with PR's that come from a fork.  This is due to the fact that the default `secrets.GITHUB_TOKEN` will only have [read access](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token).
-
-### Run on internal and remote PR
-
-If you want the action to work regardless of the source, then you can setup a github token that will have the appropriate write permissions so that it can run.  This is safe for this action as we do not access or change anything that could potentially break anything in your repo based on the conditions the user sets.
-
-
-### Only run on internal PR
-
-If you don't care about the action running from remote PR's then you can just add an `if` condition to the action:
-
-```
-name: "my-workflow"
-on: [pull_request]
-
-jobs:
-  eslint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: bradennapier/eslint-plus-action@v2
-      if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }} 
-```
-
 ## Examples
 
 ### Simple Workflow Example

--- a/README.md
+++ b/README.md
@@ -72,6 +72,32 @@ You provide configuration properties within your workflow by using the `with` pr
 
 > The official settings can always be seen by viewing the [`action.yml`](https://github.com/bradennapier/eslint-plus-action/blob/master/action.yml) schema for the action.
 
+## PR from Forks
+
+There are some considerations when working with PR's that come from a fork.  This is due to the fact that the default `secrets.GITHUB_TOKEN` will only have [read access](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token).
+
+### Run on internal and remote PR
+
+If you want the action to work regardless of the source, then you can setup a github token that will have the appropriate write permissions so that it can run.  This is safe for this action as we do not access or change anything that could potentially break anything in your repo based on the conditions the user sets.
+
+
+### Only run on internal PR
+
+If you don't care about the action running from remote PR's then you can just add an `if` condition to the action:
+
+```
+name: "my-workflow"
+on: [pull_request]
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: bradennapier/eslint-plus-action@v2
+      if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }} 
+```
+
 ## Examples
 
 ### Simple Workflow Example
@@ -88,8 +114,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: bradennapier/eslint-plus-action@v2
-      with: 
-        github-token: ${{secrets.GITHUB_TOKEN}}
 ```
 
 ### Environment Variables
@@ -105,8 +129,6 @@ jobs:
     - uses: bradennapier/eslint-plus-action@v2
       env:
         NPM_TOKEN: ${{secrets.NPM_TOKEN}}
-      with: 
-        github-token: ${{secrets.GITHUB_TOKEN}}
 ```
 
 ### Providing Parameters
@@ -121,7 +143,6 @@ jobs:
       env:
         NPM_TOKEN: ${{secrets.NPM_TOKEN}}
       with: 
-        github-token: ${{secrets.GITHUB_TOKEN}}
         issueSummaryType: full
         reportIgnoredFiles: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,7 @@ inputs:
   github-token:
     description: 'GitHub repository token for publishing inline lint annotations. Should be secrets.GITHUB_TOKEN.'
     required: true
+    default: ${{ github.token }}
   annotateWarnings:
     description: 'By setting this to "false", only errors will be annotated'
     required: false


### PR DESCRIPTION
Provides the github token by default to make it so `with:` does not need to be given with the github token secret.