### PR TITLE
Example issueSummaryOnlyOnEvent & reportWarningsAsErrors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,5 @@ jobs:
     - uses: ./
       with: 
         reportIgnoredFiles: true
+        reportWarningsAsErrors: true
+        issueSummaryOnlyOnEvent: true

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ inputs:
   issueSummaryMethod:
     description: 'When issueSummary is enabled, allows having the bot edit or refresh the comment on each new push'
     required: false
+  issueSummaryOnlyOnEvent:
+    description: 'Should an issue comment only occur when there are warnings or errors?'
+    required: false
   extensions:
     description: 'Optionally provide a comma-separated list of extensions (checks js, jsx, ts, tsx by default)'
     required: false

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.updateCheck = exports.createCheck = exports.fetchFilesBatchCommit = exports.fetchFilesBatchPR = void 0;
+exports.getCurrentWorkflow = exports.updateCheck = exports.createCheck = exports.fetchFilesBatchCommit = exports.fetchFilesBatchPR = void 0;
 const tslib_1 = require("tslib");
 const core = tslib_1.__importStar(require("@actions/core"));
 const constants_1 = require("./constants");
@@ -86,3 +86,14 @@ function updateCheck(createCheckResult, data, client, owner, repo, nextParams) {
     });
 }
 exports.updateCheck = updateCheck;
+function getCurrentWorkflow(client, data, owner = constants_1.OWNER, repo = constants_1.REPO) {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () {
+        const workflows = yield client.actions.listRepoWorkflows({
+            owner,
+            repo,
+        });
+        const currentWorkflow = workflows.data.workflows.find((workflow) => workflow.name === data.name);
+        return currentWorkflow;
+    });
+}
+exports.getCurrentWorkflow = getCurrentWorkflow;

--- a/lib/artifacts.js
+++ b/lib/artifacts.js
@@ -9,6 +9,7 @@ const artifact = tslib_1.__importStar(require("@actions/artifact"));
 const constants_1 = require("./constants");
 const fs_2 = require("./fs");
 const utils_1 = require("./utils");
+const api_1 = require("./api");
 const defaultArtifactFilter = (artifacts) => artifacts.filter((artifact) => artifact.name.startsWith(constants_1.ARTIFACT_KEY));
 function getArtifactsForRepo(client) {
     return client.actions.listArtifactsForRepo({
@@ -102,11 +103,11 @@ function getIssueState(client, data, _artifacts) {
         if (!artifact) {
             const state = lodash_clonedeep_1.default(constants_1.DEFAULT_ISSUE_STATE);
             state.issue.id = data.issueNumber;
-            state.workflow = Object.freeze(workflowState);
+            state.workflow = workflowState;
             return state;
         }
         const state = JSON.parse(artifact);
-        state.workflow = Object.freeze(workflowState);
+        state.workflow = workflowState;
         return state;
     });
 }
@@ -114,11 +115,19 @@ exports.getIssueState = getIssueState;
 function getWorkflowState(client, data, _artifacts) {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
         const [artifact] = yield downloadArtifacts(client, (artifactList) => artifactList.filter((a) => a.name === utils_1.getWorkflowStateName(data)), _artifacts || (yield getArtifactsForRepo(client)));
-        if (!artifact) {
-            console.warn('No Workflow State Found, Using Default');
-            return lodash_clonedeep_1.default(constants_1.DEFAULT_WORKFLOW_STATE);
+        const state = artifact
+            ? JSON.parse(artifact)
+            : lodash_clonedeep_1.default(constants_1.DEFAULT_WORKFLOW_STATE);
+        if (!state.id) {
+            console.log('Getting Current Workflow Information');
+            const currentWorkflow = yield api_1.getCurrentWorkflow(client, data);
+            if (currentWorkflow) {
+                state.id = currentWorkflow.id;
+                state.path = currentWorkflow.path;
+                yield updateWorkflowState(client, data, state);
+            }
         }
-        return JSON.parse(artifact);
+        return state;
     });
 }
 exports.getWorkflowState = getWorkflowState;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,15 +7,15 @@ const github = tslib_1.__importStar(require("@actions/github"));
 const guards_1 = require("./guards");
 const context = github.context;
 exports.DEFAULT_ISSUE_STATE = Object.freeze({
-    action: Object.freeze({
-        userId: undefined,
-    }),
     issue: Object.freeze({
         id: undefined,
         summaryId: undefined,
     }),
 });
 exports.DEFAULT_WORKFLOW_STATE = Object.freeze({
+    id: undefined,
+    path: undefined,
+    userId: undefined,
     scheduler: Object.freeze({
         lastRunAt: undefined,
     }),

--- a/lib/issues.js
+++ b/lib/issues.js
@@ -6,14 +6,31 @@ const constants_1 = require("./constants");
 const markdown_1 = require("./utils/markdown");
 function removeIssueSummary(client, data) {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
-        if (data.persist.issue.summaryId) {
+        if (data.issueNumber && data.persist.workflow.userId) {
+            const comments = yield client.issues.listComments({
+                owner: constants_1.OWNER,
+                repo: constants_1.REPO,
+                issue_number: data.issueNumber,
+            });
+            yield Promise.all(comments.data.reduce((arr, comment) => {
+                if (comment.user.id === data.persist.workflow.userId) {
+                    arr.push(client.issues.deleteComment({
+                        owner: constants_1.OWNER,
+                        repo: constants_1.REPO,
+                        comment_id: comment.id,
+                    }));
+                }
+                return arr;
+            }, []));
+        }
+        else if (data.persist.issue.summaryId) {
             yield client.issues.deleteComment({
                 owner: constants_1.OWNER,
                 repo: constants_1.REPO,
                 comment_id: data.persist.issue.summaryId,
             });
-            data.persist.issue.summaryId = undefined;
         }
+        data.persist.issue.summaryId = undefined;
     });
 }
 function handleIssueComment(client, data) {
@@ -26,12 +43,15 @@ function handleIssueComment(client, data) {
                 state.fixableErrorCount > 0 ||
                 state.fixableWarningCount > 0) {
                 if (data.persist.issue.summaryId && data.issueSummaryMethod === 'edit') {
-                    yield client.issues.updateComment({
+                    const result = yield client.issues.updateComment({
                         owner: constants_1.OWNER,
                         repo: constants_1.REPO,
                         comment_id: data.persist.issue.summaryId,
                         body: markdown_1.getResultMarkdownBody(data),
                     });
+                    if (!data.persist.workflow.userId) {
+                        data.persist.workflow.userId = result.data.user.id;
+                    }
                 }
                 else if (data.persist.issue.summaryId &&
                     data.issueSummaryMethod === 'refresh') {
@@ -45,7 +65,7 @@ function handleIssueComment(client, data) {
                         body: markdown_1.getResultMarkdownBody(data),
                     });
                     data.persist.issue.summaryId = commentResult.data.id;
-                    data.persist.action.userId = commentResult.data.user.id;
+                    data.persist.workflow.userId = commentResult.data.user.id;
                 }
             }
             else if (data.issueSummaryOnlyOnEvent && data.persist.issue.summaryId) {

--- a/lib/issues.js
+++ b/lib/issues.js
@@ -4,6 +4,18 @@ exports.handleIssueComment = void 0;
 const tslib_1 = require("tslib");
 const constants_1 = require("./constants");
 const markdown_1 = require("./utils/markdown");
+function removeIssueSummary(client, data) {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () {
+        if (data.persist.issue.summaryId) {
+            yield client.issues.deleteComment({
+                owner: constants_1.OWNER,
+                repo: constants_1.REPO,
+                comment_id: data.persist.issue.summaryId,
+            });
+            data.persist.issue.summaryId = undefined;
+        }
+    });
+}
 function handleIssueComment(client, data) {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
         const { state } = data;
@@ -23,12 +35,7 @@ function handleIssueComment(client, data) {
                 }
                 else if (data.persist.issue.summaryId &&
                     data.issueSummaryMethod === 'refresh') {
-                    yield client.issues.deleteComment({
-                        owner: constants_1.OWNER,
-                        repo: constants_1.REPO,
-                        comment_id: data.persist.issue.summaryId,
-                    });
-                    data.persist.issue.summaryId = undefined;
+                    yield removeIssueSummary(client, data);
                 }
                 if (!data.persist.issue.summaryId) {
                     const commentResult = yield client.issues.createComment({
@@ -40,6 +47,9 @@ function handleIssueComment(client, data) {
                     data.persist.issue.summaryId = commentResult.data.id;
                     data.persist.action.userId = commentResult.data.user.id;
                 }
+            }
+            else if (data.issueSummaryOnlyOnEvent && data.persist.issue.summaryId) {
+                yield removeIssueSummary(client, data);
             }
         }
     });

--- a/lib/quick.js
+++ b/lib/quick.js
@@ -11,13 +11,12 @@ function arrayBufferToString(buffer) {
 exports.default = arrayBufferToString;
 function run() {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
-        const artifacts = yield client.actions.listWorkflowRuns({
+        const workflows = yield client.actions.listRepoWorkflows({
             owner: 'bradennapier',
             repo: 'eslint-plus-action',
-            workflow_id: 160264279,
-            per_page: 100,
         });
-        console.log(JSON.stringify(artifacts.data), null, 2);
+        const currentWorkflow = workflows.data.workflows.find((workflow) => workflow.name === 'lint');
+        console.log(JSON.stringify(currentWorkflow, null, 2));
     });
 }
 run();

--- a/lib/quick.js
+++ b/lib/quick.js
@@ -11,11 +11,13 @@ function arrayBufferToString(buffer) {
 exports.default = arrayBufferToString;
 function run() {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
-        const artifacts = yield client.actions.listArtifactsForRepo({
+        const artifacts = yield client.actions.listWorkflowRuns({
             owner: 'bradennapier',
             repo: 'eslint-plus-action',
+            workflow_id: 160264279,
+            per_page: 100,
         });
-        console.log(JSON.stringify(artifacts.data, null, 2));
+        console.log(JSON.stringify(artifacts.data), null, 2);
     });
 }
 run();

--- a/lib/run.js
+++ b/lib/run.js
@@ -9,6 +9,7 @@ const constants_1 = require("./constants");
 const octokit_1 = require("./utils/octokit");
 const artifacts_1 = require("./artifacts");
 const issues_1 = require("./issues");
+const lodash_clonedeep_1 = tslib_1.__importDefault(require("lodash.clonedeep"));
 function run() {
     var _a, _b, _c;
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
@@ -93,7 +94,8 @@ function run() {
                 case 'synchronize':
                 default: {
                     data.persist = yield artifacts_1.getIssueState(client, data);
-                    core.info(`ENV: \n${JSON.stringify(process.env, null, 2)}`);
+                    const startState = lodash_clonedeep_1.default(data.persist);
+                    core.info(`Data:\n ${JSON.stringify(data, null, 2)}`);
                     if (data.isReadOnly && !utils_1.isSchedulerActive(data)) {
                         console.warn(`[WARN] | Read Only & schedule not found, we will not run on this PR.`);
                         return;
@@ -105,7 +107,7 @@ function run() {
                     }
                     else {
                         yield issues_1.handleIssueComment(client, data);
-                        yield artifacts_1.updateIssueState(client, data);
+                        yield utils_1.updatePersistentStateIfNeeded(client, startState, data);
                     }
                     break;
                 }

--- a/lib/run.js
+++ b/lib/run.js
@@ -93,7 +93,7 @@ function run() {
                 case 'synchronize':
                 default: {
                     data.persist = yield artifacts_1.getIssueState(client, data);
-                    core.info(`Context:\n ${JSON.stringify(data, null, 2)}`);
+                    core.info(`Context:\n ${JSON.stringify(github_1.context, null, 2)}`);
                     if (data.isReadOnly && !utils_1.isSchedulerActive(data)) {
                         console.warn(`[WARN] | Read Only & schedule not found, we will not run on this PR.`);
                         return;

--- a/lib/run.js
+++ b/lib/run.js
@@ -93,7 +93,7 @@ function run() {
                 case 'synchronize':
                 default: {
                     data.persist = yield artifacts_1.getIssueState(client, data);
-                    core.info(`Context:\n ${JSON.stringify(github_1.context, null, 2)}`);
+                    core.info(`ENV: \n${JSON.stringify(process.env, null, 2)}`);
                     if (data.isReadOnly && !utils_1.isSchedulerActive(data)) {
                         console.warn(`[WARN] | Read Only & schedule not found, we will not run on this PR.`);
                         return;

--- a/lib/run.js
+++ b/lib/run.js
@@ -107,8 +107,9 @@ function run() {
                     }
                     else {
                         yield issues_1.handleIssueComment(client, data);
-                        yield utils_1.updatePersistentStateIfNeeded(client, startState, data);
+                        yield utils_1.updateIssueStateIfNeeded(client, startState, data);
                     }
+                    yield utils_1.updateWorkflowStateIfNeeded(client, startState, data);
                     break;
                 }
             }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,10 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.processLintResults = exports.processInput = exports.processBooleanInput = exports.processEnumInput = exports.processArrayInput = exports.isSchedulerActive = exports.getIssueLintResultsName = exports.getIssueStateName = exports.getWorkflowStateName = void 0;
+exports.updatePersistentStateIfNeeded = exports.processLintResults = exports.processInput = exports.processBooleanInput = exports.processEnumInput = exports.processArrayInput = exports.isSchedulerActive = exports.getIssueLintResultsName = exports.getIssueStateName = exports.getWorkflowStateName = void 0;
 const tslib_1 = require("tslib");
+const util_1 = require("util");
 const dayjs_1 = tslib_1.__importDefault(require("dayjs"));
 const core = tslib_1.__importStar(require("@actions/core"));
 const constants_1 = require("./constants");
+const artifacts_1 = require("./artifacts");
 exports.getWorkflowStateName = (data) => `${constants_1.ARTIFACT_KEY_ISSUE_STATE}-${data.name}`;
 exports.getIssueStateName = (data) => `${constants_1.ARTIFACT_KEY_ISSUE_STATE}-${data.name}-${data.issueNumber}`;
 exports.getIssueLintResultsName = (data) => `${constants_1.ARTIFACT_KEY_LINT_RESULTS}-${data.name}-${data.issueNumber}`;
@@ -132,3 +134,18 @@ function processLintResults(engine, report, data) {
     };
 }
 exports.processLintResults = processLintResults;
+function updatePersistentStateIfNeeded(client, prevState, data) {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () {
+        const promises = [];
+        if (!util_1.isDeepStrictEqual(Object.assign(Object.assign({}, prevState), { workflow: undefined }), Object.assign(Object.assign({}, data.persist), { workflow: undefined }))) {
+            console.log('Issue State Updating');
+            promises.push(artifacts_1.updateIssueState(client, data));
+        }
+        if (!util_1.isDeepStrictEqual(prevState.workflow, data.persist.workflow)) {
+            console.log('Workflow State Updating');
+            promises.push(artifacts_1.updateWorkflowState(client, data, data.persist.workflow));
+        }
+        yield Promise.all(promises);
+    });
+}
+exports.updatePersistentStateIfNeeded = updatePersistentStateIfNeeded;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.updatePersistentStateIfNeeded = exports.processLintResults = exports.processInput = exports.processBooleanInput = exports.processEnumInput = exports.processArrayInput = exports.isSchedulerActive = exports.getIssueLintResultsName = exports.getIssueStateName = exports.getWorkflowStateName = void 0;
+exports.updateWorkflowStateIfNeeded = exports.updateIssueStateIfNeeded = exports.processLintResults = exports.processInput = exports.processBooleanInput = exports.processEnumInput = exports.processArrayInput = exports.isSchedulerActive = exports.getIssueLintResultsName = exports.getIssueStateName = exports.getWorkflowStateName = void 0;
 const tslib_1 = require("tslib");
 const util_1 = require("util");
 const dayjs_1 = tslib_1.__importDefault(require("dayjs"));
@@ -134,7 +134,7 @@ function processLintResults(engine, report, data) {
     };
 }
 exports.processLintResults = processLintResults;
-function updatePersistentStateIfNeeded(client, prevState, data) {
+function updateIssueStateIfNeeded(client, prevState, data) {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
         const promises = [];
         const prevIssueState = Object.assign(Object.assign({}, prevState), { workflow: undefined });
@@ -144,11 +144,16 @@ function updatePersistentStateIfNeeded(client, prevState, data) {
             console.log(JSON.stringify(prevIssueState, null, 2), JSON.stringify(nextIssueState, null, 2));
             promises.push(artifacts_1.updateIssueState(client, data));
         }
-        if (!util_1.isDeepStrictEqual(prevState.workflow, data.persist.workflow)) {
-            console.log('Workflow State Updating');
-            promises.push(artifacts_1.updateWorkflowState(client, data, data.persist.workflow));
-        }
         yield Promise.all(promises);
     });
 }
-exports.updatePersistentStateIfNeeded = updatePersistentStateIfNeeded;
+exports.updateIssueStateIfNeeded = updateIssueStateIfNeeded;
+function updateWorkflowStateIfNeeded(client, prevState, data) {
+    return tslib_1.__awaiter(this, void 0, void 0, function* () {
+        if (!util_1.isDeepStrictEqual(prevState.workflow, data.persist.workflow)) {
+            console.log('Workflow State Updating');
+            yield artifacts_1.updateWorkflowState(client, data, data.persist.workflow);
+        }
+    });
+}
+exports.updateWorkflowStateIfNeeded = updateWorkflowStateIfNeeded;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -152,6 +152,7 @@ function updateWorkflowStateIfNeeded(client, prevState, data) {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
         if (!util_1.isDeepStrictEqual(prevState.workflow, data.persist.workflow)) {
             console.log('Workflow State Updating');
+            console.log(JSON.stringify(prevState.workflow, null, 2), JSON.stringify(data.persist.workflow, null, 2));
             yield artifacts_1.updateWorkflowState(client, data, data.persist.workflow);
         }
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,7 +118,7 @@ function processLintResults(engine, report, data) {
                     ruleUrl: ruleDocs === null || ruleDocs === void 0 ? void 0 : ruleDocs.url,
                     ruleId,
                     message: (ruleDocs === null || ruleDocs === void 0 ? void 0 : ruleDocs.description) || '',
-                    level: severity === 2 ? 'failure' : 'warning',
+                    level,
                     annotations: [annotation],
                 });
             }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -137,8 +137,11 @@ exports.processLintResults = processLintResults;
 function updatePersistentStateIfNeeded(client, prevState, data) {
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
         const promises = [];
-        if (!util_1.isDeepStrictEqual(Object.assign(Object.assign({}, prevState), { workflow: undefined }), Object.assign(Object.assign({}, data.persist), { workflow: undefined }))) {
+        const prevIssueState = Object.assign(Object.assign({}, prevState), { workflow: undefined });
+        const nextIssueState = Object.assign(Object.assign({}, data.persist), { workflow: undefined });
+        if (!util_1.isDeepStrictEqual(prevIssueState, nextIssueState)) {
             console.log('Issue State Updating');
+            console.log(JSON.stringify(prevIssueState, null, 2), JSON.stringify(nextIssueState, null, 2));
             promises.push(artifacts_1.updateIssueState(client, data));
         }
         if (!util_1.isDeepStrictEqual(prevState.workflow, data.persist.workflow)) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,6 +8,7 @@ import {
   OctokitCreateChecksParams,
   OctokitUpdateChecksParams,
   CheckUpdaterFn,
+  GitHubWorkflow,
 } from './types';
 import { NAME, OWNER, REPO } from './constants';
 
@@ -145,4 +146,27 @@ export async function updateCheck(
   const result = await client.checks.update(params);
 
   return result;
+}
+
+/**
+ * Since the github action context does not provide the necessary information
+ * to know what our workflow id is, we will capture it and save to our workflow level
+ * state.
+ */
+export async function getCurrentWorkflow(
+  client: Octokit,
+  data: ActionData,
+  owner: string = OWNER,
+  repo: string = REPO,
+): Promise<GitHubWorkflow | undefined> {
+  const workflows = await client.actions.listRepoWorkflows({
+    owner,
+    repo,
+  });
+
+  const currentWorkflow = workflows.data.workflows.find(
+    (workflow) => workflow.name === data.name,
+  );
+
+  return currentWorkflow;
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -118,7 +118,6 @@ export async function createCheck(
   };
 
   const createCheckResult = await client.checks.create(params);
-
   data.state.checkId = createCheckResult.data.id;
 
   return (nextParams: Partial<OctokitUpdateChecksParams>) =>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,9 +18,6 @@ export const DEFAULT_ISSUE_STATE: Omit<
   IssuePersistentState,
   'workflow'
 > = Object.freeze({
-  action: Object.freeze({
-    userId: undefined,
-  }),
   issue: Object.freeze({
     id: undefined,
     summaryId: undefined,
@@ -28,6 +25,9 @@ export const DEFAULT_ISSUE_STATE: Omit<
 });
 
 export const DEFAULT_WORKFLOW_STATE: WorkflowPersistentState = Object.freeze({
+  id: undefined,
+  path: undefined,
+  userId: undefined,
   scheduler: Object.freeze({
     lastRunAt: undefined,
   }),

--- a/src/issues.ts
+++ b/src/issues.ts
@@ -1,5 +1,5 @@
 import { Octokit, ActionData } from './types';
-import { OWNER, REPO, ARTIFACTS_BASE_DIR } from './constants';
+import { OWNER, REPO } from './constants';
 import { getResultMarkdownBody } from './utils/markdown';
 
 async function removeIssueSummary(client: Octokit, data: ActionData) {

--- a/src/issues.ts
+++ b/src/issues.ts
@@ -1,5 +1,5 @@
 import { Octokit, ActionData } from './types';
-import { OWNER, REPO } from './constants';
+import { OWNER, REPO, ARTIFACTS_BASE_DIR } from './constants';
 import { getResultMarkdownBody } from './utils/markdown';
 
 async function removeIssueSummary(client: Octokit, data: ActionData) {

--- a/src/quick.ts
+++ b/src/quick.ts
@@ -59,16 +59,25 @@ async function run() {
   //   'https://api.github.com/repos/bradennapier/eslint-plus-action/actions/artifacts',
   // );
   // console.log(JSON.parse(body));
-  const artifacts = await client.actions.listWorkflowRuns({
+  const workflows = await client.actions.listRepoWorkflows({
     owner: 'bradennapier',
     repo: 'eslint-plus-action',
-    workflow_id: 160264279,
-    // workflow_id: 1581373 as any,
-    per_page: 100,
-    // per_page: 3,
   });
 
-  console.log(JSON.stringify(artifacts.data), null, 2);
+  const currentWorkflow = workflows.data.workflows.find(
+    (workflow) => workflow.name === 'lint',
+  );
+
+  // const artifacts = await client.actions.listWorkflowRuns({
+  //   owner: 'bradennapier',
+  //   repo: 'eslint-plus-action',
+  //   workflow_id: 160264279,
+  //   // workflow_id: 1581373 as any,
+  //   per_page: 100,
+  //   // per_page: 3,
+  // });
+
+  console.log(JSON.stringify(currentWorkflow, null, 2));
 
   // const running = artifacts.data.workflow_runs.reduce((arr, workflowRun) => {
   //   if (workflowRun.status !== 'completed') {

--- a/src/quick.ts
+++ b/src/quick.ts
@@ -59,11 +59,34 @@ async function run() {
   //   'https://api.github.com/repos/bradennapier/eslint-plus-action/actions/artifacts',
   // );
   // console.log(JSON.parse(body));
-  const artifacts = await client.actions.listArtifactsForRepo({
+  const artifacts = await client.actions.listWorkflowRuns({
     owner: 'bradennapier',
     repo: 'eslint-plus-action',
+    workflow_id: 160264279,
+    // workflow_id: 1581373 as any,
+    per_page: 100,
+    // per_page: 3,
   });
-  console.log(JSON.stringify(artifacts.data, null, 2));
+
+  console.log(JSON.stringify(artifacts.data), null, 2);
+
+  // const running = artifacts.data.workflow_runs.reduce((arr, workflowRun) => {
+  //   if (workflowRun.status !== 'completed') {
+  //     arr.push(workflowRun);
+  //   }
+  //   return arr;
+  // }, [] as any[]);
+
+  // await Promise.all(
+  //   running.map((workflow) =>
+  //     client.actions.cancelWorkflowRun({
+  //       owner: 'bradennapier',
+  //       repo: 'eslint-plus-action',
+  //       run_id: workflow.id,
+  //     }),
+  //   ),
+  // );
+  // console.log(JSON.stringify(running, null, 2));
 
   // await Promise.all(
   //   artifacts.data.artifacts.map((artifact) => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -164,7 +164,8 @@ async function run(): Promise<void> {
         data.persist = await getIssueState(client, data);
 
         // core.info(`Data:\n ${JSON.stringify(data, null, 2)}`);
-        core.info(`Context:\n ${JSON.stringify(context, null, 2)}`);
+        // core.info(`Context:\n ${JSON.stringify(context, null, 2)}`);
+        core.info(`ENV: \n${JSON.stringify(process.env, null, 2)}`);
         /*
           When an action is triggered by a pull request from a forked repo we will only have
           read permissions available to us.  Our solution to this is to run this action on a schedule

--- a/src/run.ts
+++ b/src/run.ts
@@ -163,8 +163,8 @@ async function run(): Promise<void> {
       default: {
         data.persist = await getIssueState(client, data);
 
-        core.info(`Context:\n ${JSON.stringify(data, null, 2)}`);
-
+        // core.info(`Data:\n ${JSON.stringify(data, null, 2)}`);
+        core.info(`Context:\n ${JSON.stringify(context, null, 2)}`);
         /*
           When an action is triggered by a pull request from a forked repo we will only have
           read permissions available to us.  Our solution to this is to run this action on a schedule

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,7 +9,8 @@ import {
   processEnumInput,
   getIssueLintResultsName,
   isSchedulerActive,
-  updatePersistentStateIfNeeded,
+  updateWorkflowStateIfNeeded,
+  updateIssueStateIfNeeded,
 } from './utils';
 import { ActionData, IssuePersistentState } from './types';
 import {
@@ -26,7 +27,6 @@ import {
   cleanupArtifactsForIssue,
   updateWorkflowState,
   getIssueState,
-  updateIssueState,
 } from './artifacts';
 import { handleIssueComment } from './issues';
 import cloneDeep from 'lodash.clonedeep';
@@ -192,10 +192,11 @@ async function run(): Promise<void> {
           await saveArtifact(getIssueLintResultsName(data), artifacts);
         } else {
           await handleIssueComment(client, data);
-          // update workflow or issue state if they changed
-          await updatePersistentStateIfNeeded(client, startState, data);
+          await updateIssueStateIfNeeded(client, startState, data);
         }
 
+        // update workflow state if changed
+        await updateWorkflowStateIfNeeded(client, startState, data);
         break;
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,10 +21,14 @@ export type IssuePersistentState = {
     summaryId: undefined | number;
   };
 
-  readonly workflow: Readonly<WorkflowPersistentState>;
+  readonly workflow: WorkflowPersistentState;
 };
 
 export type WorkflowPersistentState = {
+  /** 1581373 */
+  id?: number;
+  /** ".github/workflows/test.yml"  */
+  path?: string;
   readonly scheduler: {
     /**
      * Date that the schedule was last ran, if ever.
@@ -182,6 +186,19 @@ export type GitHubArtifact = {
   expired: boolean;
   created_at: string;
   expires_at: string;
+};
+
+export type GitHubWorkflow = {
+  id: number;
+  node_id: string;
+  name: string;
+  path: string;
+  state: string;
+  created_at: string;
+  updated_at: string;
+  url: string;
+  html_url: string;
+  badge_url: string;
 };
 
 export type ActionDataWithPR = Omit<ActionData, 'issueNumber'> & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,14 +2,6 @@ import * as github from '@actions/github';
 import { Linter } from 'eslint';
 
 export type IssuePersistentState = {
-  readonly action: {
-    /**
-     * We currently can't get this in any way but actually making a comment so we save it
-     * for future use.  This is the user that will take action when api calls are made.
-     */
-    userId: undefined | number;
-  };
-
   readonly issue: {
     /**
      * The issueNumber (pr id)
@@ -29,6 +21,11 @@ export type WorkflowPersistentState = {
   id?: number;
   /** ".github/workflows/test.yml"  */
   path?: string;
+  /**
+   * We currently can't get this in any way but actually making a comment so we save it
+   * for future use.  This is the user that will take action when api calls are made.
+   */
+  userId: undefined | number;
   readonly scheduler: {
     /**
      * Date that the schedule was last ran, if ever.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -211,7 +211,7 @@ export function processLintResults(
   };
 }
 
-export async function updatePersistentStateIfNeeded(
+export async function updateIssueStateIfNeeded(
   client: Octokit,
   prevState: IssuePersistentState,
   data: ActionData,
@@ -234,9 +234,17 @@ export async function updatePersistentStateIfNeeded(
     // issue state updated
     promises.push(updateIssueState(client, data));
   }
+
+  await Promise.all(promises);
+}
+
+export async function updateWorkflowStateIfNeeded(
+  client: Octokit,
+  prevState: IssuePersistentState,
+  data: ActionData,
+): Promise<void> {
   if (!isDeepStrictEqual(prevState.workflow, data.persist.workflow)) {
     console.log('Workflow State Updating');
-    promises.push(updateWorkflowState(client, data, data.persist.workflow));
+    await updateWorkflowState(client, data, data.persist.workflow);
   }
-  await Promise.all(promises);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -217,19 +217,20 @@ export async function updatePersistentStateIfNeeded(
   data: ActionData,
 ): Promise<void> {
   const promises: Array<Promise<unknown>> = [];
-  if (
-    !isDeepStrictEqual(
-      {
-        ...prevState,
-        workflow: undefined,
-      },
-      {
-        ...data.persist,
-        workflow: undefined,
-      },
-    )
-  ) {
+  const prevIssueState = {
+    ...prevState,
+    workflow: undefined,
+  };
+  const nextIssueState = {
+    ...data.persist,
+    workflow: undefined,
+  };
+  if (!isDeepStrictEqual(prevIssueState, nextIssueState)) {
     console.log('Issue State Updating');
+    console.log(
+      JSON.stringify(prevIssueState, null, 2),
+      JSON.stringify(nextIssueState, null, 2),
+    );
     // issue state updated
     promises.push(updateIssueState(client, data));
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -245,6 +245,10 @@ export async function updateWorkflowStateIfNeeded(
 ): Promise<void> {
   if (!isDeepStrictEqual(prevState.workflow, data.persist.workflow)) {
     console.log('Workflow State Updating');
+    console.log(
+      JSON.stringify(prevState.workflow, null, 2),
+      JSON.stringify(data.persist.workflow, null, 2),
+    );
     await updateWorkflowState(client, data, data.persist.workflow);
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -193,7 +193,7 @@ export function processLintResults(
           ruleUrl: ruleDocs?.url,
           ruleId,
           message: ruleDocs?.description || '',
-          level: severity === 2 ? 'failure' : 'warning',
+          level,
           annotations: [annotation],
         });
       } else {


### PR DESCRIPTION
These settings will only post a issue summary comment if there is a warning or error.  In addition, it will report warnings as errors.  These are good settings to use for situations where the issue summaries may be posted to slack or similar and would not be ideal to be posted unless there is something to see.

